### PR TITLE
feat: added Headers class to fetch, added .config method to fetch

### DIFF
--- a/FetchFactory.js
+++ b/FetchFactory.js
@@ -1,14 +1,40 @@
 import fetch from '@rdfjs/fetch-lite'
 
-class FetchFactory {
-  fetch (url, options = {}) {
-    const factory = typeof this.dataset === 'function' ? this : null
-    const formats = this.formats
+function createFetch (context) {
+  const result = function (url, options = {}) {
+    const factory = typeof context.dataset === 'function' ? context : null
 
-    return fetch(url, { ...options, factory, formats })
+    return fetch(url, {
+      ...options,
+      factory,
+      fetch: context._fetch.fetch,
+      formats: context.formats
+    })
   }
+
+  result.config = function (key, value) {
+    context._fetch[key] = value
+  }
+
+  result.Headers = fetch.Headers
+
+  return result
 }
 
-FetchFactory.exports = ['fetch']
+class FetchFactory {
+  init () {
+    this._fetch = {
+      fetch: null
+    }
+
+    this.fetch = createFetch(this)
+  }
+
+  clone (original) {
+    for (const [key, value] of Object.entries(original._fetch)) {
+      this._fetch[key] = value
+    }
+  }
+}
 
 export default FetchFactory

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "codecov": "^3.8.2",
     "express-as-promise": "^1.2.0",
     "mocha": "^9.0.2",
+    "nodeify-fetch": "^2.2.1",
     "stricter-standard": "^0.2.0"
   }
 }


### PR DESCRIPTION
- makes the `Headers` class from fetch available at `env.fetch.Headers`
- adds a config method to set config parameters via key-value pairs
- adds a config parameter `fetch` to change the parameter of the same name in `@rdfjs/fetch-lite`. Example: `env.fetch.config('fetch', fileFetch)`